### PR TITLE
implement thorough scrub support (zpool scrub -t)

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -59,6 +59,7 @@
 #include <sys/wait.h>
 #include <zfs_prop.h>
 #include <sys/fs/zfs.h>
+#include <sys/dsl_scan.h>
 #include <sys/stat.h>
 #include <sys/systeminfo.h>
 #include <sys/fm/fs/zfs.h>
@@ -512,8 +513,8 @@ get_usage(zpool_help_t idx)
 		return (gettext("\tinitialize [-c | -s | -u] [-w] <-a | <pool> "
 		    "[<device> ...]>\n"));
 	case HELP_SCRUB:
-		return (gettext("\tscrub [-e | -s | -p | -C | -E | -S] [-w] "
-		    "<-a | <pool> [<pool> ...]>\n"));
+		return (gettext("\tscrub [-e | -s | -p | -C | -E | -S | -t] "
+		    "[-w] <-a | <pool> [<pool> ...]>\n"));
 	case HELP_RESILVER:
 		return (gettext("\tresilver <pool> ...\n"));
 	case HELP_TRIM:
@@ -8518,7 +8519,7 @@ date_string_to_sec(const char *timestr, boolean_t rounding)
 }
 
 /*
- * zpool scrub [-e | -s | -p | -C | -E | -S] [-w] [-a | <pool> ...]
+ * zpool scrub [-e | -s | -p | -C | -E | -S | -t] [-w] [-a | <pool> ...]
  *
  *	-a	Scrub all pools.
  *	-e	Only scrub blocks in the error log.
@@ -8527,6 +8528,7 @@ date_string_to_sec(const char *timestr, boolean_t rounding)
  *	-s	Stop.  Stops any in-progress scrub.
  *	-p	Pause. Pause in-progress scrub.
  *	-w	Wait.  Blocks until scrub has completed.
+ *	-t	Decompress and decrypt (if key is loaded) scrubbed blocks.
  *	-C	Scrub from last saved txg.
  */
 int
@@ -8538,23 +8540,25 @@ zpool_do_scrub(int argc, char **argv)
 	int error;
 
 	cb.cb_type = POOL_SCAN_SCRUB;
-	cb.cb_scrub_cmd = POOL_SCRUB_NORMAL;
+	cb.cb_scrub_cmd = 0;
 	cb.cb_date_start = cb.cb_date_end = 0;
 
 	boolean_t is_error_scrub = B_FALSE;
 	boolean_t is_pause = B_FALSE;
 	boolean_t is_stop = B_FALSE;
-	boolean_t is_txg_continue = B_FALSE;
 	boolean_t scrub_all = B_FALSE;
 
 	/* check options */
-	while ((c = getopt(argc, argv, "aspweCE:S:")) != -1) {
+	while ((c = getopt(argc, argv, "aspweCE:S:t")) != -1) {
 		switch (c) {
 		case 'a':
 			scrub_all = B_TRUE;
 			break;
 		case 'e':
 			is_error_scrub = B_TRUE;
+			break;
+		case 't':
+			cb.cb_scrub_cmd |= POOL_SCRUB_THOROUGH;
 			break;
 		case 'E':
 			/*
@@ -8576,7 +8580,7 @@ zpool_do_scrub(int argc, char **argv)
 			wait = B_TRUE;
 			break;
 		case 'C':
-			is_txg_continue = B_TRUE;
+			cb.cb_scrub_cmd |= POOL_SCRUB_FROM_LAST_TXG;
 			break;
 		case '?':
 			(void) fprintf(stderr, gettext("invalid option '%c'\n"),
@@ -8589,17 +8593,30 @@ zpool_do_scrub(int argc, char **argv)
 		(void) fprintf(stderr, gettext("invalid option "
 		    "combination: -s and -p are mutually exclusive\n"));
 		usage(B_FALSE);
-	} else if (is_pause && is_txg_continue) {
+	} else if (is_pause && (cb.cb_scrub_cmd & POOL_SCRUB_FROM_LAST_TXG)) {
 		(void) fprintf(stderr, gettext("invalid option "
 		    "combination: -p and -C are mutually exclusive\n"));
 		usage(B_FALSE);
-	} else if (is_stop && is_txg_continue) {
+	} else if (is_stop && (cb.cb_scrub_cmd & POOL_SCRUB_FROM_LAST_TXG)) {
 		(void) fprintf(stderr, gettext("invalid option "
 		    "combination: -s and -C are mutually exclusive\n"));
 		usage(B_FALSE);
-	} else if (is_error_scrub && is_txg_continue) {
+	} else if (is_error_scrub &&
+	    (cb.cb_scrub_cmd & POOL_SCRUB_FROM_LAST_TXG)) {
 		(void) fprintf(stderr, gettext("invalid option "
 		    "combination: -e and -C are mutually exclusive\n"));
+		usage(B_FALSE);
+	} else if (is_error_scrub && (cb.cb_scrub_cmd & POOL_SCRUB_THOROUGH)) {
+		(void) fprintf(stderr, gettext("invalid option "
+		    "combination: -e and -t are mutually exclusive\n"));
+		usage(B_FALSE);
+	} else if (is_pause && (cb.cb_scrub_cmd & POOL_SCRUB_THOROUGH)) {
+		(void) fprintf(stderr, gettext("invalid option "
+		    "combination: -p and -t are mutually exclusive\n"));
+		usage(B_FALSE);
+	} else if (is_stop && (cb.cb_scrub_cmd & POOL_SCRUB_THOROUGH)) {
+		(void) fprintf(stderr, gettext("invalid option "
+		    "combination: -s and -t are mutually exclusive\n"));
 		usage(B_FALSE);
 	} else {
 		if (is_error_scrub)
@@ -8609,19 +8626,23 @@ zpool_do_scrub(int argc, char **argv)
 			cb.cb_scrub_cmd = POOL_SCRUB_PAUSE;
 		} else if (is_stop) {
 			cb.cb_type = POOL_SCAN_NONE;
-		} else if (is_txg_continue) {
-			cb.cb_scrub_cmd = POOL_SCRUB_FROM_LAST_TXG;
 		} else {
-			cb.cb_scrub_cmd = POOL_SCRUB_NORMAL;
+			if (cb.cb_scrub_cmd == 0)
+				cb.cb_scrub_cmd = POOL_SCRUB_NORMAL;
 		}
 	}
 
+	uint64_t scrub_kind = cb.cb_scrub_cmd & (POOL_SCRUB_NORMAL |
+	    POOL_SCRUB_THOROUGH);
 	if ((cb.cb_date_start != 0 || cb.cb_date_end != 0) &&
-	    cb.cb_scrub_cmd != POOL_SCRUB_NORMAL) {
-		(void) fprintf(stderr, gettext("invalid option combination: "
-		    "start/end date is available only with normal scrub\n"));
+	    scrub_kind != POOL_SCRUB_NORMAL &&
+	    scrub_kind != POOL_SCRUB_THOROUGH) {
+		(void) fprintf(stderr, gettext("invalid option "
+		    "combination: start/end date is available only "
+		    "with normal or thorough scrub\n"));
 		usage(B_FALSE);
 	}
+
 	if (cb.cb_date_start != 0 && cb.cb_date_end != 0 &&
 	    cb.cb_date_start > cb.cb_date_end) {
 		(void) fprintf(stderr, gettext("invalid arguments: "
@@ -8941,7 +8962,7 @@ print_err_scrub_status(pool_scan_stat_t *ps)
  * Print out detailed scrub status.
  */
 static void
-print_scan_scrub_resilver_status(pool_scan_stat_t *ps)
+print_scan_scrub_resilver_status(pool_scan_stat_t *ps, uint_t c)
 {
 	time_t start, end, pause;
 	uint64_t pass_scanned, scanned, pass_issued, issued, total_s, total_i;
@@ -8976,10 +8997,22 @@ print_scan_scrub_resilver_status(pool_scan_stat_t *ps)
 		secs_to_dhms(end - start, time_buf);
 
 		if (is_scrub) {
-			(void) printf(gettext("scrub repaired %s "
-			    "in %s with %llu errors on %s"), processed_buf,
-			    time_buf, (u_longlong_t)ps->pss_errors,
-			    ctime(&end));
+			boolean_t is_thorough =
+			    (c > offsetof(pool_scan_stat_t,
+			    pss_pass_scrub_flags) / 8) &&
+			    (ps->pss_pass_scrub_flags & DSF_SCRUB_THOROUGH) !=
+			    0;
+			if (is_thorough) {
+				(void) printf(gettext("thorough scrub repaired"
+				    " %s in %s with %llu errors on %s"),
+				    processed_buf, time_buf,
+				    (u_longlong_t)ps->pss_errors, ctime(&end));
+			} else {
+				(void) printf(gettext("scrub repaired %s "
+				    "in %s with %llu errors on %s"),
+				    processed_buf, time_buf,
+				    (u_longlong_t)ps->pss_errors, ctime(&end));
+			}
 		} else if (is_resilver) {
 			(void) printf(gettext("resilvered %s "
 			    "in %s with %llu errors on %s"), processed_buf,
@@ -8989,8 +9022,18 @@ print_scan_scrub_resilver_status(pool_scan_stat_t *ps)
 		return;
 	} else if (ps->pss_state == DSS_CANCELED) {
 		if (is_scrub) {
-			(void) printf(gettext("scrub canceled on %s"),
-			    ctime(&end));
+			boolean_t is_thorough =
+			    (c > offsetof(pool_scan_stat_t,
+			    pss_pass_scrub_flags) / 8) &&
+			    (ps->pss_pass_scrub_flags & DSF_SCRUB_THOROUGH) !=
+			    0;
+			if (is_thorough) {
+				(void) printf(gettext("thorough scrub canceled"
+				    " on %s"), ctime(&end));
+			} else {
+				(void) printf(gettext("scrub canceled on %s"),
+				    ctime(&end));
+			}
 		} else if (is_resilver) {
 			(void) printf(gettext("resilver canceled on %s"),
 			    ctime(&end));
@@ -9002,14 +9045,30 @@ print_scan_scrub_resilver_status(pool_scan_stat_t *ps)
 
 	/* Scan is in progress. Resilvers can't be paused. */
 	if (is_scrub) {
+		boolean_t is_thorough =
+		    (c > offsetof(pool_scan_stat_t,
+		    pss_pass_scrub_flags) / 8) &&
+		    (ps->pss_pass_scrub_flags & DSF_SCRUB_THOROUGH) != 0;
 		if (pause == 0) {
-			(void) printf(gettext("scrub in progress since %s"),
-			    ctime(&start));
+			if (is_thorough) {
+				(void) printf(gettext("thorough scrub in "
+				    "progress since %s"), ctime(&start));
+			} else {
+				(void) printf(gettext("scrub in progress "
+				    "since %s"), ctime(&start));
+			}
 		} else {
-			(void) printf(gettext("scrub paused since %s"),
-			    ctime(&pause));
-			(void) printf(gettext("\tscrub started on %s"),
-			    ctime(&start));
+			if (is_thorough) {
+				(void) printf(gettext("thorough scrub "
+				    "paused since %s"), ctime(&pause));
+				(void) printf(gettext("\tthorough scrub "
+				    "started on %s"), ctime(&start));
+			} else {
+				(void) printf(gettext("scrub paused since %s"),
+				    ctime(&pause));
+				(void) printf(gettext("\tscrub started on %s"),
+				    ctime(&start));
+			}
 		}
 	} else if (is_resilver) {
 		(void) printf(gettext("resilver in progress since %s"),
@@ -10124,7 +10183,7 @@ print_scan_status(zpool_handle_t *zhp, nvlist_t *nvroot)
 
 	/* Always print the scrub status when available. */
 	if (have_scrub && scrub_start > errorscrub_start)
-		print_scan_scrub_resilver_status(ps);
+		print_scan_scrub_resilver_status(ps, c);
 	else if (have_errorscrub && errorscrub_start >= scrub_start)
 		print_err_scrub_status(ps);
 
@@ -10134,7 +10193,7 @@ print_scan_status(zpool_handle_t *zhp, nvlist_t *nvroot)
 	 */
 	if (active_resilver || (!active_rebuild && have_resilver &&
 	    resilver_end_time && resilver_end_time > rebuild_end_time)) {
-		print_scan_scrub_resilver_status(ps);
+		print_scan_scrub_resilver_status(ps, c);
 	} else if (active_rebuild || (!active_resilver && have_rebuild &&
 	    rebuild_end_time && rebuild_end_time > resilver_end_time)) {
 		print_rebuild_status(zhp, nvroot);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -4230,7 +4230,7 @@ ztest_device_removal(ztest_ds_t *zd, uint64_t id)
 	 * strategy employed by ztest_fault_inject() when selecting which
 	 * offset are redundant and can be damaged.
 	 */
-	error = spa_scan(spa, POOL_SCAN_SCRUB);
+	error = spa_scan(spa, POOL_SCAN_SCRUB, POOL_SCRUB_NORMAL);
 	if (error == 0) {
 		while (dsl_scan_scrubbing(spa_get_dsl(spa)))
 			txg_wait_synced(spa_get_dsl(spa), 0);
@@ -6704,7 +6704,7 @@ out:
 	mutex_exit(&ztest_vdev_lock);
 
 	if (injected && ztest_opts.zo_raid_do_expand) {
-		int error = spa_scan(spa, POOL_SCAN_SCRUB);
+		int error = spa_scan(spa, POOL_SCAN_SCRUB, POOL_SCRUB_NORMAL);
 		if (error == 0) {
 			while (dsl_scan_scrubbing(spa_get_dsl(spa)))
 				txg_wait_synced(spa_get_dsl(spa), 0);
@@ -6737,7 +6737,7 @@ out:
 static int
 ztest_scrub_impl(spa_t *spa)
 {
-	int error = spa_scan(spa, POOL_SCAN_SCRUB);
+	int error = spa_scan(spa, POOL_SCAN_SCRUB, POOL_SCRUB_NORMAL);
 	if (error)
 		return (error);
 
@@ -6771,7 +6771,7 @@ ztest_scrub(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * Start a scrub, wait a moment, then force a restart.
 	 */
-	(void) spa_scan(spa, POOL_SCAN_SCRUB);
+	(void) spa_scan(spa, POOL_SCAN_SCRUB, POOL_SCRUB_NORMAL);
 	(void) poll(NULL, 0, 100);
 
 	error = ztest_scrub_impl(spa);
@@ -7464,7 +7464,7 @@ ztest_spa_import_export(char *oldname, char *newname)
 	 * Kick off a scrub to tickle scrub/export races.
 	 */
 	if (ztest_random(2) == 0)
-		(void) spa_scan(spa, POOL_SCAN_SCRUB);
+		(void) spa_scan(spa, POOL_SCAN_SCRUB, POOL_SCRUB_NORMAL);
 
 	pool_guid = spa_guid(spa);
 	spa_close(spa, FTAG);

--- a/include/sys/dsl_scan.h
+++ b/include/sys/dsl_scan.h
@@ -76,8 +76,10 @@ typedef struct dsl_scan_phys {
 typedef enum dsl_scan_flags {
 	DSF_VISIT_DS_AGAIN = 1<<0,
 	DSF_SCRUB_PAUSED = 1<<1,
+	DSF_SCRUB_THOROUGH = 1<<2,
 } dsl_scan_flags_t;
 
+/* #2094 overflow recovery only allows DSF_VISIT_DS_AGAIN in the extra word. */
 #define	DSL_SCAN_FLAGS_MASK (DSF_VISIT_DS_AGAIN)
 
 typedef struct dsl_errorscrub_phys {
@@ -184,6 +186,7 @@ typedef struct {
 	pool_scan_func_t func;
 	uint64_t	 txgstart;
 	uint64_t	 txgend;
+	dsl_scan_flags_t flags;
 } setup_sync_arg_t;
 
 typedef struct dsl_scan_io_queue dsl_scan_io_queue_t;
@@ -197,7 +200,7 @@ void dsl_scan_fini(struct dsl_pool *dp);
 void dsl_scan_sync(struct dsl_pool *, dmu_tx_t *);
 int dsl_scan_cancel(struct dsl_pool *);
 int dsl_scan(struct dsl_pool *, pool_scan_func_t, uint64_t starttxg,
-    uint64_t txgend);
+    uint64_t txgend, dsl_scan_flags_t flags);
 void dsl_scan_assess_vdev(struct dsl_pool *dp, vdev_t *vd);
 boolean_t dsl_scan_scrubbing(const struct dsl_pool *dp);
 boolean_t dsl_errorscrubbing(const struct dsl_pool *dp);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1203,13 +1203,15 @@ typedef enum pool_scan_func {
 } pool_scan_func_t;
 
 /*
- * Used to control scrub pause and resume.
+ * Used to select scrub modes.  POOL_SCRUB_NORMAL and POOL_SCRUB_THOROUGH
+ * are mutually exclusive scrub kinds; POOL_SCRUB_FROM_LAST_TXG may be ORed
+ * with exactly one of them.
  */
 typedef enum pool_scrub_cmd {
-	POOL_SCRUB_NORMAL = 0,
-	POOL_SCRUB_PAUSE,
-	POOL_SCRUB_FROM_LAST_TXG,
-	POOL_SCRUB_FLAGS_END
+	POOL_SCRUB_NORMAL = 1<<0,
+	POOL_SCRUB_PAUSE = 1<<1,
+	POOL_SCRUB_FROM_LAST_TXG = 1<<2,
+	POOL_SCRUB_THOROUGH = 1<<3,
 } pool_scrub_cmd_t;
 
 typedef enum {
@@ -1302,6 +1304,7 @@ typedef struct pool_scan_stat {
 	/* error scrub values not stored on disk */
 	/* error scrub pause time in milliseconds */
 	uint64_t	pss_pass_error_scrub_pause;
+	uint64_t	pss_pass_scrub_flags;
 
 } pool_scan_stat_t;
 

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -848,9 +848,9 @@ extern void spa_l2cache_activate(vdev_t *vd);
 extern void spa_l2cache_drop(spa_t *spa);
 
 /* scanning */
-extern int spa_scan(spa_t *spa, pool_scan_func_t func);
+extern int spa_scan(spa_t *spa, pool_scan_func_t func, uint64_t flags);
 extern int spa_scan_range(spa_t *spa, pool_scan_func_t func, uint64_t txgstart,
-    uint64_t txgend);
+    uint64_t txgend, uint64_t flags);
 extern int spa_scan_stop(spa_t *spa);
 extern int spa_scrub_pause_resume(spa_t *spa, pool_scrub_cmd_t flag);
 

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -6478,10 +6478,10 @@
     <typedef-decl name='pool_scan_func_t' type-id='1b092565' id='7313fbe2'/>
     <enum-decl name='pool_scrub_cmd' id='a1474cbd'>
       <underlying-type type-id='9cac1fee'/>
-      <enumerator name='POOL_SCRUB_NORMAL' value='0'/>
-      <enumerator name='POOL_SCRUB_PAUSE' value='1'/>
-      <enumerator name='POOL_SCRUB_FROM_LAST_TXG' value='2'/>
-      <enumerator name='POOL_SCRUB_FLAGS_END' value='3'/>
+      <enumerator name='POOL_SCRUB_NORMAL' value='1'/>
+      <enumerator name='POOL_SCRUB_PAUSE' value='2'/>
+      <enumerator name='POOL_SCRUB_FROM_LAST_TXG' value='4'/>
+      <enumerator name='POOL_SCRUB_THOROUGH' value='8'/>
     </enum-decl>
     <typedef-decl name='pool_scrub_cmd_t' type-id='a1474cbd' id='b51cf3c2'/>
     <enum-decl name='zpool_errata' id='d9abbf54'>

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -2907,6 +2907,24 @@ out:
 }
 
 /*
+ * POOL_SCRUB_NORMAL and POOL_SCRUB_THOROUGH are mutually exclusive scrub
+ * modes; POOL_SCRUB_FROM_LAST_TXG may be combined with either.
+ */
+static boolean_t
+scrub_cmd_is_start(pool_scrub_cmd_t cmd)
+{
+	if (cmd & POOL_SCRUB_PAUSE)
+		return (B_FALSE);
+	if ((cmd & POOL_SCRUB_NORMAL) && (cmd & POOL_SCRUB_THOROUGH))
+		return (B_FALSE);
+	if (cmd & ~(POOL_SCRUB_NORMAL | POOL_SCRUB_THOROUGH |
+	    POOL_SCRUB_FROM_LAST_TXG))
+		return (B_FALSE);
+	return ((cmd & (POOL_SCRUB_NORMAL | POOL_SCRUB_THOROUGH |
+	    POOL_SCRUB_FROM_LAST_TXG)) != 0);
+}
+
+/*
  * Scan the pool.
  */
 int
@@ -2959,7 +2977,7 @@ zpool_scan_range(zpool_handle_t *zhp, pool_scan_func_t func,
 	 * failures when an older kernel returns ECANCELED in those cases.
 	 */
 	if (err == ECANCELED && (func == POOL_SCAN_SCRUB ||
-	    func == POOL_SCAN_ERRORSCRUB) && cmd == POOL_SCRUB_NORMAL)
+	    func == POOL_SCAN_ERRORSCRUB) && scrub_cmd_is_start(cmd))
 		return (0);
 	/*
 	 * The following cases have been handled here:
@@ -2979,13 +2997,13 @@ zpool_scan_range(zpool_handle_t *zhp, pool_scan_func_t func,
 			    dgettext(TEXT_DOMAIN, "cannot pause scrubbing %s"),
 			    zhp->zpool_name);
 		} else {
-			assert(cmd == POOL_SCRUB_NORMAL);
+			ASSERT(scrub_cmd_is_start(cmd));
 			(void) snprintf(errbuf, sizeof (errbuf),
 			    dgettext(TEXT_DOMAIN, "cannot scrub %s"),
 			    zhp->zpool_name);
 		}
 	} else if (func == POOL_SCAN_RESILVER) {
-		assert(cmd == POOL_SCRUB_NORMAL);
+		ASSERT3U(cmd, ==, POOL_SCRUB_NORMAL);
 		(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
 		    "cannot restart resilver on %s"), zhp->zpool_name);
 	} else if (func == POOL_SCAN_NONE) {
@@ -3019,13 +3037,13 @@ zpool_scan_range(zpool_handle_t *zhp, pool_scan_func_t func,
 		    ps->pss_state == DSS_SCANNING) {
 			if (ps->pss_pass_scrub_pause == 0) {
 				/* handles case 1 */
-				assert(cmd == POOL_SCRUB_NORMAL);
+				ASSERT(scrub_cmd_is_start(cmd));
 				return (zfs_error(hdl, EZFS_SCRUBBING,
 				    errbuf));
 			} else {
 				if (func == POOL_SCAN_ERRORSCRUB) {
 					/* handles case 2 */
-					ASSERT3U(cmd, ==, POOL_SCRUB_NORMAL);
+					ASSERT(scrub_cmd_is_start(cmd));
 					return (zfs_error(hdl,
 					    EZFS_SCRUB_PAUSED_TO_CANCEL,
 					    errbuf));
@@ -3042,7 +3060,7 @@ zpool_scan_range(zpool_handle_t *zhp, pool_scan_func_t func,
 		    ps->pss_error_scrub_state == DSS_ERRORSCRUBBING) {
 			if (ps->pss_pass_error_scrub_pause == 0) {
 				/* handles case 4 */
-				ASSERT3U(cmd, ==, POOL_SCRUB_NORMAL);
+				ASSERT(scrub_cmd_is_start(cmd));
 				return (zfs_error(hdl, EZFS_ERRORSCRUBBING,
 				    errbuf));
 			} else {

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -2181,7 +2181,7 @@ working on a scrub between TXG flushes.
 .It Sy zfs_scrub_error_blocks_per_txg Ns = Ns Sy 4096 Pq uint
 Error blocks to be scrubbed in one txg.
 .
-.It Sy zfs_scan_checkpoint_intval Ns = Ns Sy 7200 Ns s Po 2 hour Pc Pq uint
+.It Sy zfs_scan_checkpoint_intval Ns = Ns Sy 7200 Ns s Po 2 hours Pc Pq uint
 To preserve progress across reboots, the sequential scan algorithm periodically
 needs to stop metadata scanning and issue all the verification I/O to disk.
 The frequency of this flushing is determined by this tunable.

--- a/man/man8/zpool-scrub.8
+++ b/man/man8/zpool-scrub.8
@@ -38,7 +38,7 @@
 .Sh SYNOPSIS
 .Nm zpool
 .Cm scrub
-.Op Ns Fl e | Ns Fl p | Fl s Ns | Fl C Ns
+.Op Ns Fl e | Ns Fl p | Fl s Ns | Fl C Ns | Fl t Ns
 .Op Fl w
 .Op Fl S Ar date
 .Op Fl E Ar date
@@ -123,10 +123,21 @@ The pool must have been scrubbed at least once with the
 feature enabled to use this option.
 Error scrubbing cannot be run simultaneously with regular scrubbing or
 resilvering, nor can it be run when a regular scrub is paused.
+It cannot be combined with thorough scrub.
+.Pq Fl t .
 .It Fl C
 Continue scrub from last saved txg (see zpool
 .Sy last_scrubbed_txg
 property).
+.It Fl t
+Thorough scrub.
+Will cause scrub to decrypt and decompress blocks it reads so that it will
+catch the rare type of corruption where the checksum matches the data, but
+decryption and/or decompression fails.
+For encrypted datasets keys have to be loaded in order to perform
+thorough scrub.
+If keys are not loaded or unloaded during a thorough scrub the scrub will revert
+to doing a normal scrub for the encrypted dataset blocks.
 .It Fl S Ar date , Fl E Ar date
 Allows specifying the date range for blocks created between these dates.
 .Bl -bullet -compact -offset indent

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -26,6 +26,7 @@
  * Copyright (c) 2017, 2019, Datto Inc. All rights reserved.
  * Copyright (c) 2015, Nexenta Systems, Inc. All rights reserved.
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2026 ConnectWise, Inc.
  */
 
 #include <sys/dsl_scan.h>
@@ -33,6 +34,7 @@
 #include <sys/dsl_dataset.h>
 #include <sys/dsl_prop.h>
 #include <sys/dsl_dir.h>
+#include <sys/dsl_crypt.h>
 #include <sys/dsl_synctask.h>
 #include <sys/dnode.h>
 #include <sys/dmu_tx.h>
@@ -56,6 +58,7 @@
 #include <sys/abd.h>
 #include <sys/range_tree.h>
 #include <sys/dbuf.h>
+#include <sys/fm/fs/zfs.h>
 #ifdef _KERNEL
 #include <sys/zfs_vfsops.h>
 #endif
@@ -291,6 +294,10 @@ typedef struct scan_io {
 	uint64_t		sio_birth;
 	zio_cksum_t		sio_cksum;
 	uint32_t		sio_nr_dvas;
+	uint64_t		sio_salt;
+	uint64_t		sio_iv1;
+	uint64_t		sio_iv2;
+
 
 	/* fields from zio_t */
 	uint32_t		sio_flags;
@@ -446,6 +453,11 @@ sio2bp(const scan_io_t *sio, blkptr_t *bp)
 	BP_SET_PHYSICAL_BIRTH(bp, sio->sio_phys_birth);
 	BP_SET_LOGICAL_BIRTH(bp, sio->sio_birth);
 	bp->blk_fill = 1;	/* we always only work with data pointers */
+	if (BP_IS_ENCRYPTED(bp)) {
+		bp->blk_dva[2].dva_word[0] = sio->sio_salt;
+		bp->blk_dva[2].dva_word[1] = sio->sio_iv1;
+		BP_SET_IV2(bp, sio->sio_iv2);
+	}
 	bp->blk_cksum = sio->sio_cksum;
 
 	ASSERT3U(sio->sio_nr_dvas, >, 0);
@@ -462,6 +474,11 @@ bp2sio(const blkptr_t *bp, scan_io_t *sio, int dva_i)
 	sio->sio_birth = BP_GET_LOGICAL_BIRTH(bp);
 	sio->sio_cksum = bp->blk_cksum;
 	sio->sio_nr_dvas = BP_GET_NDVAS(bp);
+	if (BP_IS_ENCRYPTED(bp)) {
+		sio->sio_salt = bp->blk_dva[2].dva_word[0];
+		sio->sio_iv1 = bp->blk_dva[2].dva_word[1];
+		sio->sio_iv2 = BP_GET_IV2(bp);
+	}
 
 	/*
 	 * Copy the DVAs to the sio. We need all copies of the block so
@@ -886,6 +903,7 @@ dsl_scan_setup_sync(void *arg, dmu_tx_t *tx)
 	dsl_errorscrub_sync_state(scn, tx);
 
 	scn->scn_phys.scn_func = setup_sync_arg->func;
+	scn->scn_phys.scn_flags = setup_sync_arg->flags;
 	scn->scn_phys.scn_state = DSS_SCANNING;
 	scn->scn_phys.scn_min_txg = setup_sync_arg->txgstart;
 	if (setup_sync_arg->txgend == 0) {
@@ -990,7 +1008,7 @@ dsl_scan_setup_sync(void *arg, dmu_tx_t *tx)
  */
 int
 dsl_scan(dsl_pool_t *dp, pool_scan_func_t func, uint64_t txgstart,
-    uint64_t txgend)
+    uint64_t txgend, dsl_scan_flags_t flags)
 {
 	spa_t *spa = dp->dp_spa;
 	dsl_scan_t *scn = dp->dp_scan;
@@ -1023,6 +1041,9 @@ dsl_scan(dsl_pool_t *dp, pool_scan_func_t func, uint64_t txgstart,
 			/*
 			 * got error scrub start cmd, resume paused error scrub.
 			 */
+			if (flags != 0)
+				return (SET_ERROR(ENOTSUP));
+
 			int err = dsl_scrub_set_pause_resume(scn->scn_dp,
 			    POOL_SCRUB_NORMAL);
 			if (err == 0) {
@@ -1040,6 +1061,9 @@ dsl_scan(dsl_pool_t *dp, pool_scan_func_t func, uint64_t txgstart,
 
 	if (func == POOL_SCAN_SCRUB && dsl_scan_is_paused_scrub(scn)) {
 		/* got scrub start cmd, resume paused scrub */
+		if (flags != 0)
+			return (SET_ERROR(ENOTSUP));
+
 		int err = dsl_scrub_set_pause_resume(scn->scn_dp,
 		    POOL_SCRUB_NORMAL);
 		if (err == 0) {
@@ -1052,6 +1076,7 @@ dsl_scan(dsl_pool_t *dp, pool_scan_func_t func, uint64_t txgstart,
 	setup_sync_arg.func = func;
 	setup_sync_arg.txgstart = txgstart;
 	setup_sync_arg.txgend = txgend;
+	setup_sync_arg.flags = flags;
 
 	return (dsl_sync_task(spa_name(spa), dsl_scan_setup_check,
 	    dsl_scan_setup_sync, &setup_sync_arg, 0,
@@ -4030,8 +4055,11 @@ read_by_block_level(dsl_scan_t *scn, zbookmark_phys_t zb)
 		return;
 	}
 
-	int zio_flags = ZIO_FLAG_SCAN_THREAD | ZIO_FLAG_RAW |
-	    ZIO_FLAG_CANFAIL | ZIO_FLAG_SCRUB;
+	int zio_flags = ZIO_FLAG_SCAN_THREAD | ZIO_FLAG_CANFAIL |
+	    ZIO_FLAG_SCRUB;
+
+	if (!(scn->scn_phys.scn_flags & DSF_SCRUB_THOROUGH))
+		zio_flags |= ZIO_FLAG_RAW;
 
 	/* If it's an intent log block, failure is expected. */
 	if (zb.zb_level == ZB_ZIL_LEVEL)
@@ -4832,7 +4860,11 @@ dsl_scan_scrub_cb(dsl_pool_t *dp,
 	uint64_t phys_birth = BP_GET_PHYSICAL_BIRTH(bp);
 	size_t psize = BP_GET_PSIZE(bp);
 	boolean_t needs_io = B_FALSE;
-	int zio_flags = ZIO_FLAG_SCAN_THREAD | ZIO_FLAG_RAW | ZIO_FLAG_CANFAIL;
+	int zio_flags = ZIO_FLAG_SCAN_THREAD | ZIO_FLAG_CANFAIL;
+
+	if (!(scn->scn_phys.scn_flags & DSF_SCRUB_THOROUGH)) {
+		zio_flags |= ZIO_FLAG_RAW;
+	}
 
 	count_block(dp->dp_blkstats, bp);
 	if (phys_birth <= scn->scn_phys.scn_min_txg ||
@@ -4908,8 +4940,16 @@ dsl_scan_scrub_done(zio_t *zio)
 		mutex_exit(&queue->q_vd->vdev_scan_io_queue_lock);
 	}
 
+	/*
+	 * Similar to zio_done(), we ignore EACCES errors during scrub when the
+	 * encryption key is not loaded (see spa_do_crypt_abd() and the MAC
+	 * helpers). The block's checksum has already been verified, so we treat
+	 * the scrub as successful for this block as this (a normal scurb) is
+	 * as much as we can do when keys are not loaded.
+	 */
 	if (zio->io_error && (zio->io_error != ECKSUM ||
-	    !(zio->io_flags & ZIO_FLAG_SPECULATIVE))) {
+	    !(zio->io_flags & ZIO_FLAG_SPECULATIVE)) &&
+	    !(zio->io_error == EACCES && (zio->io_flags & ZIO_FLAG_SCRUB))) {
 		if (dsl_errorscrubbing(spa->spa_dsl_pool) &&
 		    !dsl_errorscrub_is_paused(spa->spa_dsl_pool->dp_scan)) {
 			atomic_inc_64(&spa->spa_dsl_pool->dp_scan
@@ -4934,7 +4974,9 @@ scan_exec_io(dsl_pool_t *dp, const blkptr_t *bp, int zio_flags,
 {
 	spa_t *spa = dp->dp_spa;
 	dsl_scan_t *scn = dp->dp_scan;
-	size_t size = BP_GET_PSIZE(bp);
+
+	size_t size = (zio_flags & ZIO_FLAG_RAW) ?
+	    BP_GET_PSIZE(bp) : BP_GET_LSIZE(bp);
 	abd_t *data = abd_alloc_for_io(size, B_FALSE);
 	zio_t *pio;
 

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -9681,16 +9681,21 @@ spa_scan_stop(spa_t *spa)
 }
 
 int
-spa_scan(spa_t *spa, pool_scan_func_t func)
+spa_scan(spa_t *spa, pool_scan_func_t func, uint64_t flags)
 {
-	return (spa_scan_range(spa, func, 0, 0));
+	return (spa_scan_range(spa, func, 0, 0, flags));
 }
 
 int
 spa_scan_range(spa_t *spa, pool_scan_func_t func, uint64_t txgstart,
-    uint64_t txgend)
+    uint64_t txgend, uint64_t flags)
 {
+	uint64_t dsl_flags = 0;
+
 	ASSERT0(spa_config_held(spa, SCL_ALL, RW_WRITER));
+
+	if (flags & POOL_SCRUB_THOROUGH)
+		dsl_flags |= DSF_SCRUB_THOROUGH;
 
 	if (func >= POOL_SCAN_FUNCS || func == POOL_SCAN_NONE)
 		return (SET_ERROR(ENOTSUP));
@@ -9716,7 +9721,7 @@ spa_scan_range(spa_t *spa, pool_scan_func_t func, uint64_t txgstart,
 	    !spa_feature_is_enabled(spa, SPA_FEATURE_HEAD_ERRLOG))
 		return (SET_ERROR(ENOTSUP));
 
-	return (dsl_scan(spa->spa_dsl_pool, func, txgstart, txgend));
+	return (dsl_scan(spa->spa_dsl_pool, func, txgstart, txgend, dsl_flags));
 }
 
 /*

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2885,6 +2885,7 @@ spa_scan_get_stats(spa_t *spa, pool_scan_stat_t *ps)
 
 	/* error scrub data not stored on disk */
 	ps->pss_pass_error_scrub_pause = spa->spa_scan_pass_errorscrub_pause;
+	ps->pss_pass_scrub_flags = scn->scn_phys.scn_flags;
 
 	return (0);
 }

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1884,6 +1884,53 @@ zfs_ioc_pool_tryimport(zfs_cmd_t *zc)
 }
 
 /*
+ * Validate scrub-related ioctls: scan type, command bits, and optional
+ * date range must be mutually consistent.
+ */
+static int
+zfs_scrub_ioc_validate(uint64_t scan_type, uint64_t scan_cmd,
+    uint64_t date_start, uint64_t date_end)
+{
+	if (scan_type >= POOL_SCAN_FUNCS)
+		return (SET_ERROR(EINVAL));
+
+	if (scan_cmd & ~(POOL_SCRUB_NORMAL | POOL_SCRUB_PAUSE |
+	    POOL_SCRUB_FROM_LAST_TXG | POOL_SCRUB_THOROUGH))
+		return (SET_ERROR(EINVAL));
+
+	if ((scan_cmd & POOL_SCRUB_PAUSE) && (scan_cmd != POOL_SCRUB_PAUSE))
+		return (SET_ERROR(EINVAL));
+
+	if ((scan_cmd & POOL_SCRUB_NORMAL) && (scan_cmd & POOL_SCRUB_THOROUGH))
+		return (SET_ERROR(EINVAL));
+
+	if (scan_type != POOL_SCAN_SCRUB &&
+	    (date_start != 0 || date_end != 0))
+		return (SET_ERROR(EINVAL));
+
+	if (scan_type != POOL_SCAN_SCRUB &&
+	    (scan_cmd & POOL_SCRUB_FROM_LAST_TXG))
+		return (SET_ERROR(EINVAL));
+
+	if (scan_type != POOL_SCAN_SCRUB &&
+	    (scan_cmd & POOL_SCRUB_THOROUGH))
+		return (SET_ERROR(EINVAL));
+
+	if (scan_type == POOL_SCAN_RESILVER && scan_cmd != POOL_SCRUB_PAUSE &&
+	    (scan_cmd & ~POOL_SCRUB_NORMAL) != 0)
+		return (SET_ERROR(EINVAL));
+
+	if (scan_type == POOL_SCAN_NONE && scan_cmd != 0)
+		return (SET_ERROR(EINVAL));
+
+	if (scan_cmd == POOL_SCRUB_PAUSE &&
+	    (date_start != 0 || date_end != 0))
+		return (SET_ERROR(EINVAL));
+
+	return (0);
+}
+
+/*
  * inputs:
  * zc_name              name of the pool
  * zc_cookie            scan func (pool_scan_func_t)
@@ -1895,21 +1942,21 @@ zfs_ioc_pool_scan(zfs_cmd_t *zc)
 	spa_t *spa;
 	int error;
 
-	if (zc->zc_flags >= POOL_SCRUB_FLAGS_END)
-		return (SET_ERROR(EINVAL));
+	if ((error = zfs_scrub_ioc_validate(zc->zc_cookie, zc->zc_flags, 0,
+	    0)) != 0)
+		return (error);
 
 	if ((error = spa_open(zc->zc_name, &spa, FTAG)) != 0)
 		return (error);
 
-	if (zc->zc_flags == POOL_SCRUB_PAUSE)
+	if (zc->zc_flags & POOL_SCRUB_PAUSE) {
 		error = spa_scrub_pause_resume(spa, POOL_SCRUB_PAUSE);
-	else if (zc->zc_cookie == POOL_SCAN_NONE)
+	} else if (zc->zc_cookie == POOL_SCAN_NONE)
 		error = spa_scan_stop(spa);
 	else
-		error = spa_scan(spa, zc->zc_cookie);
+		error = spa_scan(spa, zc->zc_cookie, zc->zc_flags);
 
 	spa_close(spa, FTAG);
-
 	return (error);
 }
 
@@ -1939,13 +1986,14 @@ zfs_ioc_pool_scrub(const char *poolname, nvlist_t *innvl, nvlist_t *outnvl)
 	if (nvlist_lookup_uint64(innvl, "scan_command", &scan_cmd) != 0)
 		return (SET_ERROR(EINVAL));
 
-	if (scan_cmd >= POOL_SCRUB_FLAGS_END)
-		return (SET_ERROR(EINVAL));
-
 	if (nvlist_lookup_uint64(innvl, "scan_date_start", &date_start) != 0)
 		date_start = 0;
 	if (nvlist_lookup_uint64(innvl, "scan_date_end", &date_end) != 0)
 		date_end = 0;
+
+	if ((error = zfs_scrub_ioc_validate(scan_type, scan_cmd, date_start,
+	    date_end)) != 0)
+		return (error);
 
 	if ((error = spa_open(poolname, &spa, FTAG)) != 0)
 		return (error);
@@ -1954,13 +2002,13 @@ zfs_ioc_pool_scrub(const char *poolname, nvlist_t *innvl, nvlist_t *outnvl)
 		error = spa_scrub_pause_resume(spa, POOL_SCRUB_PAUSE);
 	} else if (scan_type == POOL_SCAN_NONE) {
 		error = spa_scan_stop(spa);
-	} else if (scan_cmd == POOL_SCRUB_FROM_LAST_TXG) {
-		error = spa_scan_range(spa, scan_type,
-		    spa_get_last_scrubbed_txg(spa), 0);
 	} else {
-		uint64_t txg_start, txg_end;
+		uint64_t txg_start = 0, txg_end = 0;
 
-		txg_start = txg_end = 0;
+		if (scan_cmd & POOL_SCRUB_FROM_LAST_TXG) {
+			txg_start = spa_get_last_scrubbed_txg(spa);
+		}
+
 		if (date_start != 0 || date_end != 0) {
 			mutex_enter(&spa->spa_txg_log_time_lock);
 			if (date_start != 0) {
@@ -1975,7 +2023,8 @@ zfs_ioc_pool_scrub(const char *poolname, nvlist_t *innvl, nvlist_t *outnvl)
 			mutex_exit(&spa->spa_txg_log_time_lock);
 		}
 
-		error = spa_scan_range(spa, scan_type, txg_start, txg_end);
+		error = spa_scan_range(spa, scan_type, txg_start, txg_end,
+		    scan_cmd);
 	}
 
 	spa_close(spa, FTAG);

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -682,7 +682,8 @@ zio_decrypt(zio_t *zio, abd_t *data, uint64_t size)
 
 error:
 	/* assert that the key was found unless this was speculative */
-	ASSERT(ret != EACCES || (zio->io_flags & ZIO_FLAG_SPECULATIVE));
+	ASSERT(ret != EACCES || (zio->io_flags &
+	    (ZIO_FLAG_SPECULATIVE | ZIO_FLAG_SCRUB)));
 
 	/*
 	 * If there was a decryption / authentication error return EIO as
@@ -5645,7 +5646,16 @@ zio_done(zio_t *zio)
 		}
 	}
 
-	if (zio->io_error) {
+	/*
+	 * During scrub, if the dataset key is not loaded, decryption or MAC
+	 * verification fails with EACCES (spa_do_crypt_abd() and the MAC
+	 * helpers). Since the block's checksum was already successfully
+	 * verified by zio_checksum_verify() before we got here, we can
+	 * safely ignore this error and move on as this (normal scrub) is as
+	 * much as we can do without the keys loaded.
+	 */
+	if (zio->io_error &&
+	    !(zio->io_error == EACCES && (zio->io_flags & ZIO_FLAG_SCRUB))) {
 		/*
 		 * If this I/O is attached to a particular vdev,
 		 * generate an error message describing the I/O failure

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -562,7 +562,8 @@ tests = ['zpool_scrub_001_neg', 'zpool_scrub_002_pos', 'zpool_scrub_003_pos',
     'zpool_scrub_multiple_pools',
     'zpool_error_scrub_001_pos', 'zpool_error_scrub_002_pos',
     'zpool_error_scrub_003_pos', 'zpool_error_scrub_004_pos',
-    'zpool_scrub_date_range_001', 'zpool_scrub_date_range_002']
+    'zpool_scrub_date_range_001', 'zpool_scrub_date_range_002',
+    'zpool_scrub_thorough']
 tags = ['functional', 'cli_root', 'zpool_scrub']
 
 [tests/functional/cli_root/zpool_set]

--- a/tests/zfs-tests/cmd/libzfs_input_check.c
+++ b/tests/zfs-tests/cmd/libzfs_input_check.c
@@ -698,7 +698,7 @@ test_scrub(const char *pool)
 {
 	nvlist_t *required = fnvlist_alloc();
 	fnvlist_add_uint64(required, "scan_type", POOL_SCAN_FUNCS + 1);
-	fnvlist_add_uint64(required, "scan_command", POOL_SCRUB_FLAGS_END + 1);
+	fnvlist_add_uint64(required, "scan_command", 0xDEADBEEF);
 	IOC_INPUT_TEST(ZFS_IOC_POOL_SCRUB, pool, required, NULL, EINVAL);
 	nvlist_free(required);
 }

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1282,6 +1282,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_scrub/zpool_error_scrub_002_pos.ksh \
 	functional/cli_root/zpool_scrub/zpool_error_scrub_003_pos.ksh \
 	functional/cli_root/zpool_scrub/zpool_error_scrub_004_pos.ksh \
+	functional/cli_root/zpool_scrub/zpool_scrub_thorough.ksh \
 	functional/cli_root/zpool_set/cleanup.ksh \
 	functional/cli_root/zpool_set/setup.ksh \
 	functional/cli_root/zpool/setup.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_thorough.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_thorough.ksh
@@ -1,0 +1,147 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2025 ConnectWise Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
+
+#
+# DESCRIPTION:
+# 'zpool scrub' with thorough scrub enabled works with various configurations:
+# 1) Compressed dataset
+# 2) Compressed and encrypted dataset
+# 3) Encrypted dataset
+# 4) Compressed and encrypted dataset with keys unloaded
+# 5) Compressed and encrypted dataset with key unloaded during thorough scrub
+# 6) Verify thorough scrub pause/resume
+# 7) Verify incompatible flags with -t (including error scrub)
+# 8) Verify compatible flags with -t
+#
+
+function cleanup
+{
+	datasetexists $TESTPOOL/comp && destroy_dataset $TESTPOOL/comp
+	datasetexists $TESTPOOL/comp_enc && destroy_dataset $TESTPOOL/comp_enc
+	datasetexists $TESTPOOL/enc && destroy_dataset $TESTPOOL/enc
+	datasetexists $TESTPOOL/comp_enc_unloaded && destroy_dataset $TESTPOOL/comp_enc_unloaded
+	datasetexists $TESTPOOL/comp_enc_unloading && destroy_dataset $TESTPOOL/comp_enc_unloading
+}
+
+verify_runnable "global"
+
+log_onexit cleanup
+
+log_assert "Thorough scrub works with various dataset configurations."
+
+# 1) Compressed dataset
+log_must zfs create $TESTPOOL/comp
+log_must zfs set compression=on $TESTPOOL/comp
+typeset file_comp="/$TESTPOOL/comp/$TESTFILE0"
+log_must dd if=/dev/urandom of=$file_comp bs=1024 count=1024 oflag=sync
+# Make sure data is compressible
+log_must eval "echo 'aaaaaaaa' >> $file_comp"
+
+# 2) Compressed and encrypted dataset
+log_must eval "echo 'password' | zfs create -o encryption=on -o keyformat=passphrase $TESTPOOL/comp_enc"
+log_must zfs set compression=on $TESTPOOL/comp_enc
+typeset file_comp_enc="/$TESTPOOL/comp_enc/$TESTFILE0"
+log_must dd if=/dev/urandom of=$file_comp_enc bs=1024 count=1024 oflag=sync
+log_must eval "echo 'aaaaaaaa' >> $file_comp_enc"
+
+# 3) Encrypted dataset
+log_must eval "echo 'password' | zfs create -o encryption=on -o keyformat=passphrase $TESTPOOL/enc"
+log_must zfs set compression=off $TESTPOOL/enc
+typeset file_enc="/$TESTPOOL/enc/$TESTFILE0"
+log_must dd if=/dev/urandom of=$file_enc bs=1024 count=1024 oflag=sync
+
+# 4) Compressed and encrypted dataset with keys unloaded
+log_must eval "echo 'password' | zfs create -o encryption=on -o keyformat=passphrase $TESTPOOL/comp_enc_unloaded"
+log_must zfs set compression=on $TESTPOOL/comp_enc_unloaded
+typeset file_comp_enc_unloaded="/$TESTPOOL/comp_enc_unloaded/$TESTFILE0"
+log_must dd if=/dev/urandom of=$file_comp_enc_unloaded bs=1024 count=1024 oflag=sync
+log_must eval "echo 'aaaaaaaa' >> $file_comp_enc_unloaded"
+
+log_must zfs unmount $TESTPOOL/comp_enc_unloaded
+log_must zfs unload-key $TESTPOOL/comp_enc_unloaded
+
+# Run and wait for thorough scrub
+log_must zpool scrub -t -w $TESTPOOL
+log_must check_pool_status $TESTPOOL "scan" "thorough"
+
+log_must check_pool_status $TESTPOOL "scan" "with 0 errors"
+log_must check_pool_status $TESTPOOL "errors" "No known data errors"
+
+# 5) Compressed and encrypted dataset with key unloaded during scrub
+log_must eval "echo 'password' | zfs create -o encryption=on -o keyformat=passphrase $TESTPOOL/comp_enc_unloading"
+log_must zfs set compression=on $TESTPOOL/comp_enc_unloading
+typeset file_enc_unloading="/$TESTPOOL/comp_enc_unloading/$TESTFILE0"
+# Write enough data to allow time for unloading key
+log_must dd if=/dev/urandom of=$file_enc_unloading bs=1024 count=10240 oflag=sync
+log_must eval "echo 'aaaaaaaa' >> $file_enc_unloading"
+
+log_must zfs unmount $TESTPOOL/comp_enc_unloading
+# Key is still loaded
+
+# Start scrub (async)
+log_must zpool scrub -t $TESTPOOL
+
+# Unload key while scrub is running
+log_must zfs unload-key $TESTPOOL/comp_enc_unloading
+
+# Wait for scrub
+log_must zpool wait -t scrub $TESTPOOL
+
+log_must check_pool_status $TESTPOOL "scan" "with 0 errors"
+log_must check_pool_status $TESTPOOL "errors" "No known data errors"
+
+# Run and wait for normal scrub
+log_must zpool scrub -w $TESTPOOL
+
+log_must check_pool_status $TESTPOOL "scan" "with 0 errors"
+log_must check_pool_status $TESTPOOL "errors" "No known data errors"
+
+# 6) Verify thorough scrub pause/resume
+log_must zpool scrub -t $TESTPOOL
+sleep 3
+log_must check_pool_status $TESTPOOL "scan" "thorough"
+log_must zpool scrub -p $TESTPOOL
+sleep 3
+log_must zpool scrub $TESTPOOL
+log_must zpool wait -t scrub $TESTPOOL
+
+log_must zpool scrub -t $TESTPOOL
+sleep 3
+log_must check_pool_status $TESTPOOL "scan" "thorough"
+log_must zpool scrub -p $TESTPOOL
+sleep 3
+log_must zpool scrub -t $TESTPOOL
+log_must check_pool_status $TESTPOOL "scan" "thorough"
+log_must zpool wait -t scrub $TESTPOOL
+log_must check_pool_status $TESTPOOL "scan" "thorough"
+
+
+# 7) Verify incompatible flags with -t
+log_mustnot zpool scrub -s -t $TESTPOOL
+log_mustnot zpool scrub -p -t $TESTPOOL
+log_mustnot zpool scrub -t -e $TESTPOOL
+
+# 8) Verify compatible flags with -t
+log_must zpool scrub -t -w $TESTPOOL
+log_must zpool sync $TESTPOOL
+log_must zpool scrub -t -C $TESTPOOL
+log_must zpool wait -t scrub $TESTPOOL
+
+log_pass "Thorough scrub works with various dataset configurations."


### PR DESCRIPTION
This introduces the -t (thorough) flag to 'zpool scrub' command. A thorough scrub decrypts and decompresses blocks as they are read, allowing ZFS to catch rare corruption scenarios where the block's checksum matches the data on disk, but the block fails to decrypt or decompress.

For encrypted datasets, the keys must be loaded to perform a thorough scrub. If the keys are not loaded, or are unloaded while the scrub is in progress, the scrub will fall back to a normal scrub for those encrypted blocks with key unloaded.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
